### PR TITLE
Fixed the type error from upgraded Scipy (> 1.4.1)

### DIFF
--- a/phenograph/core.py
+++ b/phenograph/core.py
@@ -148,8 +148,8 @@ def parallel_jaccard_kernel(idx):
 
     graph = sp.lil_matrix((n, n), dtype=float)
     for i, tup in enumerate(jaccard_values):
-        graph.rows[i] = tup[0]
-        graph.data[i] = tup[1]
+        graph.rows[i] = tup[0].tolist()
+        graph.data[i] = tup[1].tolist()
 
     i, j = graph.nonzero()
     s = graph.tocoo().data


### PR DESCRIPTION
Fixed the type error which results from the upgrade to Scipy > 1.4.1. This previously resulted from the way the sparse lil graph was constructed (using ndarray instead of list values) which requires lists as arguments.