### PR TITLE
fix: `n_jobs` in cluster.cluster() not working

### DIFF
--- a/phenograph/cluster.py
+++ b/phenograph/cluster.py
@@ -287,11 +287,12 @@ def cluster(
         print("Setting directed=False because prune=True")
         directed = False
 
+    kernelargs = {}
     if n_jobs == 1:
         kernel = jaccard_kernel
     else:
+        kernelargs["n_jobs"] = n_jobs
         kernel = parallel_jaccard_kernel
-    kernelargs = {}
 
     # Start timer
     tic = time.time()


### PR DESCRIPTION
Fix bug that there are more processes than expected after setting n_jobs in phenograph.cluster() function.